### PR TITLE
Fix: Adds theme supported component to fix dark-mode

### DIFF
--- a/src/components/errors/_ErrorPage.tsx
+++ b/src/components/errors/_ErrorPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import {Wrapper} from "@storybook/blocks";
 
 const statusCodes = {
   400: 'Bad Request',
@@ -30,18 +31,12 @@ const ErrorPage = ({ statusCode, errorMessage, title }: Props) => {
   }, [ErorrTitle]);
 
   return (
-    <section
-      className={`
-    fixed top-[76px] left-0 
-    w-screen h-screen 
-    flex flex-col items-center gap-8 
-    pt-[10%] 
-    bg-white dark:bg-black
-  `}
-    >
-      <h2 className="text-2xl">{ErorrTitle}</h2>
-      {errorMessage && <p>{errorMessage}</p>}
-    </section>
+    <Wrapper className={`bg-white dark:bg-black`}>
+      <section className={`fixed top-[76px] left-0 w-screen h-screen flex flex-col items-center gap-8 pt-[10%]`}>
+        <h2 className="text-2xl">{ErorrTitle}</h2>
+        {errorMessage && <p>{errorMessage}</p>}
+      </section>
+    </Wrapper>
   );
 };
 export default ErrorPage;


### PR DESCRIPTION
Wraps the error page in a theme supported component.

<img width="940" height="450" alt="image" src="https://github.com/user-attachments/assets/fe494ffb-7675-421f-8ace-4176bcfeaa1f" />


closes #42 