### PR TITLE
Fix: Fixes inviteUser to ensure bool value is passed to mutation

### DIFF
--- a/src/components/addUserToOrg/AddUserSheet.tsx
+++ b/src/components/addUserToOrg/AddUserSheet.tsx
@@ -4,7 +4,7 @@ import addGroupMember from '@/lib/mutation/organizations/addGroupMember';
 import { useMutation } from '@apollo/client';
 import { Sheet } from '@uselagoon/ui-library';
 import { UserRoundPlus } from 'lucide-react';
-import {toast} from "sonner";
+import { toast } from 'sonner';
 
 const AddUserSheet = ({
   groupSelectOptions = [],
@@ -21,7 +21,7 @@ const AddUserSheet = ({
     onCompleted: () => {
       toast.success('User added successfully');
     },
-    onError: (err) => {
+    onError: err => {
       console.error('Error adding user:', err);
       toast.error('Error adding user', {
         id: 'add_user_error',
@@ -33,7 +33,7 @@ const AddUserSheet = ({
   const handleAddUser = async (e: React.MouseEvent<HTMLButtonElement>, values: any) => {
     try {
       const { email, group, role, inviteUser } = values;
-      const inviteUserBool = Boolean(inviteUser)
+      const inviteUserBool = Boolean(inviteUser);
 
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       if (!emailRegex.test(email)) {
@@ -62,7 +62,7 @@ const AddUserSheet = ({
       <Sheet
         sheetTrigger={iconOnly ? <UserRoundPlus className="h-5 w-5" /> : 'Add User'}
         sheetTitle="Add users"
-        sheetDescription="Enter the user details below, this user must already be a Lagoon user."
+        sheetDescription="Enter the user details below."
         sheetFooterButton="Confirm"
         loading={loading}
         error={!!error}


### PR DESCRIPTION
When adding a `User` in Organizations, the invite user `Checkbox` in the `AddUserSheet` would set the value as a `string` instead of a `boolean`. This updates the value to ensure it is always a bool & adds toasts for success and failure for better UX.

<img width="1142" height="533" alt="image" src="https://github.com/user-attachments/assets/c2869cdd-a625-4cf7-9263-c123048ce757" />


References Notion #819479