### PR TITLE
Changes: Batched feedback changes

### DIFF
--- a/src/app/(routegroups)/(orgroutes)/layout.tsx
+++ b/src/app/(routegroups)/(orgroutes)/layout.tsx
@@ -1,7 +1,6 @@
 /**
  * Layout wrapping Organizations related routes
  */
-import { OrgBreadcrumbs } from '@/components/breadcrumbs/OrgBreadcrumbs';
 
 export default async function ProjectRoutesLayout({
   children,
@@ -10,7 +9,6 @@ export default async function ProjectRoutesLayout({
 }>) {
   return (
     <>
-      <OrgBreadcrumbs />
       {children}
     </>
   );

--- a/src/app/(routegroups)/(projectroutes)/projects/(projects-page)/loading.tsx
+++ b/src/app/(routegroups)/(projectroutes)/projects/(projects-page)/loading.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import SectionWrapper from '@/components/SectionWrapper/SectionWrapper';
-import { ProjectBreadcrumbs } from '@/components/breadcrumbs/ProjectBreadcrumbs';
 import ProjectsTableColumns from '@/components/pages/projects/DataTableColumns';
 import { Button, DataTable, SelectWithOptions } from '@uselagoon/ui-library';
 import { useQueryStates } from 'nuqs';
@@ -27,7 +26,6 @@ export default function Loading() {
 
   return (
     <>
-      <ProjectBreadcrumbs />
       <SectionWrapper>
         <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">Projects</h3>
         <Button className="px-0" variant="link">

--- a/src/app/(routegroups)/alldeployments/layout.tsx
+++ b/src/app/(routegroups)/alldeployments/layout.tsx
@@ -1,7 +1,6 @@
 /**
  * Layout wrapping AllDeployments page
  */
-import { AllDeploymentsBreadcrumbs } from '@/components/breadcrumbs/AllDeploymentsBreadcrumbs';
 
 export default async function ProjectRoutesLayout({
   children,
@@ -10,7 +9,6 @@ export default async function ProjectRoutesLayout({
 }>) {
   return (
     <>
-      <AllDeploymentsBreadcrumbs />
       {children}
     </>
   );

--- a/src/app/(routegroups)/settings/layout.tsx
+++ b/src/app/(routegroups)/settings/layout.tsx
@@ -1,8 +1,6 @@
 /**
  * Project navigation layout wrapping settings tabs.
  */
-import { SettingsBreadcrumbs } from '@/components/breadcrumbs/SettingsBreadcrumbs';
-import SettingsNavTabs from '@/components/settingsNavtabs/SettingsNavTabs';
 
 export default async function ProjectLayout({
   children,
@@ -11,8 +9,7 @@ export default async function ProjectLayout({
 }>) {
   return (
     <>
-      <SettingsBreadcrumbs />
-      <SettingsNavTabs>{children}</SettingsNavTabs>
+      {children}
     </>
   );
 }

--- a/src/components/pages/organizations/organization/OrganizationPage.tsx
+++ b/src/components/pages/organizations/organization/OrganizationPage.tsx
@@ -40,11 +40,6 @@ export default function OrganizationPage({
 
   const orgDetailedItems = [
     {
-      key: 'org_id',
-      label: 'ORG ID',
-      children: organization.id,
-    },
-    {
       key: 'org_name',
       label: 'ORG NAME',
       children: organization.name,

--- a/src/components/pages/projects/ProjectsPage.tsx
+++ b/src/components/pages/projects/ProjectsPage.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/navigation';
 
 import { ProjectsData } from '@/app/(routegroups)/(projectroutes)/projects/(projects-page)/page';
 import SectionWrapper from '@/components/SectionWrapper/SectionWrapper';
-import { ProjectBreadcrumbs } from '@/components/breadcrumbs/ProjectBreadcrumbs';
 import { Button, DataTable, SelectWithOptions } from '@uselagoon/ui-library';
 import { useQueryStates } from 'nuqs';
 
@@ -33,7 +32,6 @@ export default function ProjectsPage({ data }: { data: ProjectsData }) {
 
   return (
     <>
-      <ProjectBreadcrumbs />
       <SectionWrapper>
         <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">Projects</h3>
         <Button className="px-0" variant="link">


### PR DESCRIPTION
Fixes a number of Feedback tasks:

- #388877: Removes `OrgID` `DetailStat` component
- #388875: Fixes logo to link to `home`
- #388874: Removes root `BreadCrumbs`
- #388873: Moves `All Deployments` to be nested under Projects
- #388872: Removes `BreadCrumbs` and `NavTabs` from Settings


| Issue | Screenshot |
|------|------------|
| **#388872: Removes `BreadCrumbs` and `NavTabs` from Settings** | <img width="957" height="276" alt="image" src="https://github.com/user-attachments/assets/3b927c8e-d59c-41ad-9629-5675bc497f41" /> |
| **#388873:Moves All Deployments to be nested under Projects** | <img width="419" height="537" alt="image" src="https://github.com/user-attachments/assets/9924f110-a62c-49a1-b9ed-f3f8165b9d7c" /> |
| **#388874: Removes root `BreadCrumbs`** | <img width="1678" height="557" alt="image" src="https://github.com/user-attachments/assets/7cfbcfa4-8c6a-430d-8d49-5726ff34183e" /> |
| **#388875: Fixes logo to link to `home`** | <img width="373" height="163" alt="image" src="https://github.com/user-attachments/assets/8a6b92f5-a1f6-44b0-94ff-e734a48a96d2" /> |
| **#388877: Removes `OrgID` `DetailStat` component** | <img width="1514" height="629" alt="image" src="https://github.com/user-attachments/assets/94bcffbc-544c-42c4-b3f5-2cae03c7a4b0" /> |