### PR TITLE
Changes: Batched feedback changes #2

### DIFF
--- a/src/app/(routegroups)/(projectroutes)/projects/[projectSlug]/(project-overview)/loading.tsx
+++ b/src/app/(routegroups)/(projectroutes)/projects/[projectSlug]/(project-overview)/loading.tsx
@@ -18,8 +18,8 @@ export default function Loading() {
     },
 
     env_count: {
-      defaultValue: 5,
-      parse: (value: string | undefined) => (value !== undefined ? Number(value) : 5),
+      defaultValue: 10,
+      parse: (value: string | undefined) => (value !== undefined ? Number(value) : 10),
     },
   });
 

--- a/src/components/pages/environment/_components/LimitedRoutes.tsx
+++ b/src/components/pages/environment/_components/LimitedRoutes.tsx
@@ -1,4 +1,4 @@
-import { FC, JSX, useState } from 'react';
+import React, { FC, JSX, useState } from 'react';
 
 import { RoutesWrapper } from '../styles';
 
@@ -8,7 +8,9 @@ interface Props {
 const LimitedRoutes: FC<Props> = ({ routes }) => {
   const [expanded, setExpanded] = useState(false);
 
-  const [firstFiveRoutes, ...otherRoutes] = [routes.slice(0, 5), ...routes.slice(5)];
+  const actualRoutes = React.Children.toArray(routes);
+
+  const [firstFiveRoutes, ...otherRoutes] = [actualRoutes.slice(0, 5), ...actualRoutes.slice(5)];
   const leftOverLength = otherRoutes.length;
 
   const handleExpand = () => setExpanded(true);

--- a/src/components/pages/environments/ProjectEnvironmentsPage.tsx
+++ b/src/components/pages/environments/ProjectEnvironmentsPage.tsx
@@ -38,8 +38,8 @@ export default function ProjectEnvironmentsPage({
     },
 
     env_count: {
-      defaultValue: 5,
-      parse: (value: string | undefined) => (value !== undefined ? Number(value) : 5),
+      defaultValue: 10,
+      parse: (value: string | undefined) => (value !== undefined ? Number(value) : 10),
     },
   });
 
@@ -118,10 +118,6 @@ export default function ProjectEnvironmentsPage({
           renderFilters={table => (
             <SelectWithOptions
               options={[
-                {
-                  label: '5 results per page',
-                  value: 5,
-                },
                 {
                   label: '10 results per page',
                   value: 10,

--- a/src/components/pages/environments/ProjectEnvsTableColumns.tsx
+++ b/src/components/pages/environments/ProjectEnvsTableColumns.tsx
@@ -10,6 +10,7 @@ import { Badge, Button, DataTableColumnDef, Tooltip, TooltipContent, TooltipTrig
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import utc from 'dayjs/plugin/utc';
+import LimitedRoutes from "@/components/pages/environment/_components/LimitedRoutes";
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);
@@ -117,9 +118,9 @@ const getProjectEnvsTableColumns = (basePath: string) =>
       accessorKey: 'activeRoutes',
       cell: ({ row }) => {
         const activeRoutes = row.original.activeRoutes;
-
-        return <>{activeRoutes}</>;
-      },
+        const routes = activeRoutes?.props?.children
+        return <LimitedRoutes routes={routes} />;
+      }
     },
   ] as DataTableColumnDef<TableDataType>[];
 

--- a/src/components/pages/organizations/DataTableColumns.tsx
+++ b/src/components/pages/organizations/DataTableColumns.tsx
@@ -58,10 +58,10 @@ export const OrganizationsTableColumns: DataTableColumnDef<OrgType>[] = [
     },
 
     cell: ({ row }) => {
-      const organizationName = row.original.name;
+      const organizationName = row.original.friendlyName;
       return (
         <div className="max-w-[25vw]">
-          <Link className="hover:text-blue-800 transition-colors" href={`/organizations/${organizationName}`}>
+          <Link className="hover:text-blue-800 transition-colors" href={`/organizations/${row.original.name}`}>
             {organizationName}
           </Link>
         </div>

--- a/src/components/pages/organizations/organization/_components/Description.tsx
+++ b/src/components/pages/organizations/organization/_components/Description.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from 'react';
 
-import { Input, Skeleton } from '@uselagoon/ui-library';
+import {Input, Skeleton, Textarea} from '@uselagoon/ui-library';
 
 import { EditDesc } from './EditDesc';
 import { EditName } from './EditName';
@@ -58,8 +58,8 @@ const DescriptionData: FC<DescriptionProps> = ({ orgId, name, description }) => 
 
       <div className="flex flex-col gap-1 mb-3.5 mt-6">
         <span>Organization Description</span>
-        <section className="flex gap-4 items-center">
-          <Input defaultValue={description || ' - '} onChange={e => setNewDesc(e.target.value)} />
+        <section className="flex gap-4 items-center w-1/2">
+          <Textarea defaultValue={description || ' - '} onChange={e => setNewDesc(e.target.value)} />
           {isChangedDesc && <EditDesc orgId={orgId} description={newDesc} />}
         </section>
       </div>

--- a/src/components/pages/projectDetails/projectDetailsPage.tsx
+++ b/src/components/pages/projectDetails/projectDetailsPage.tsx
@@ -54,13 +54,13 @@ export default function ProjectDetailsPage(props: ProjectDetailsProps) {
     {
       key: 'branches',
       title: 'BRANCHES ENABLED',
-      children: project.branches,
+      children: <span className="break-words text-lg">{project.branches}</span>,
       lowercaseValue: true,
     },
     {
       key: 'pulls',
       title: 'PULL REQUESTS ENABLED',
-      children: project.pullrequests,
+      children: <span className="break-words text-lg">{project.pullrequests}</span>,
       lowercaseValue: true,
     },
     {


### PR DESCRIPTION
Fixes a number of Feedback tasks:

#388868: Uses the `friendlyName` for the allOrganizations table
#388869: Creates a `TextArea` component and uses it in place of the `Input`
#388880: Changes minimum results per page from `5` to `10` to be consistent with the rest of the `DataTable's`
#388884: Fixed overflow on `DetailStat` component
#388957: Limits the number of `routes` to `5` with the option to display all

| Issue | Screenshot |
|------|------------|
| **#388868: Uses the `friendlyName` for the allOrganizations table** | <img width="1346" height="491" alt="image" src="https://github.com/user-attachments/assets/e281207e-7ad8-452b-864c-00c1e07269b0" /> |
| **#388869: Creates a `TextArea` component and uses it in place of the `Input`** | <img width="821" height="355" alt="image" src="https://github.com/user-attachments/assets/fd927367-3da9-4758-9f37-033446d0188f" /> |
| **#388880: Changes minimum results per page from `5` to `10` to be consistent with the rest of the `DataTable's`** | <img width="1321" height="613" alt="image" src="https://github.com/user-attachments/assets/cb21e1fb-8c97-496f-965d-a2cb42e0b847" /> |
| **#388884: Fixed overflow on `DetailStat` component** | <img width="901" height="480" alt="image" src="https://github.com/user-attachments/assets/9de81129-d31d-447d-91f1-7b725ab77966" /> |
| **#388957: Limits the number of `routes` to `5` with the option to display all** | <img width="1354" height="466" alt="image" src="https://github.com/user-attachments/assets/a24b106c-d9f9-4703-829e-2acfbf0ad552" /> |