### PR TITLE
chore: remove deprecated internal_container_registry scope

### DIFF
--- a/src/components/addNewVariable/AddNewVariable.tsx
+++ b/src/components/addNewVariable/AddNewVariable.tsx
@@ -38,10 +38,6 @@ const scopeOptions = [
     label: 'Container registry',
     value: 'container_registry',
   },
-  {
-    label: 'Internal container registry',
-    value: 'internal_container_registry',
-  },
 ];
 
 export const AddNewVariable: FC<Props> = ({ type, refetch, onClick, ...rest }) => {

--- a/src/components/pages/environmentVariables/_components/filterValues.tsx
+++ b/src/components/pages/environmentVariables/_components/filterValues.tsx
@@ -19,10 +19,6 @@ export const scopeOptions = [
     label: 'Container registry',
     value: 'container_registry',
   },
-  {
-    label: 'Internal container registry',
-    value: 'internal_container_registry',
-  },
 ];
 export const sortOptions = [
   {

--- a/src/components/pages/organizations/variables/_components/filterValues.tsx
+++ b/src/components/pages/organizations/variables/_components/filterValues.tsx
@@ -19,10 +19,6 @@ export const scopeOptions = [
     label: 'Container registry',
     value: 'container_registry',
   },
-  {
-    label: 'Internal container registry',
-    value: 'internal_container_registry',
-  },
 ];
 export const sortOptions = [
   {

--- a/src/components/pages/projectVariables/_components/EditVariable.tsx
+++ b/src/components/pages/projectVariables/_components/EditVariable.tsx
@@ -43,10 +43,6 @@ const scopeOptions = [
     label: 'Container registry',
     value: 'container_registry',
   },
-  {
-    label: 'Internal container registry',
-    value: 'internal_container_registry',
-  },
 ];
 
 export const EditVariable: FC<Props> = ({ currentEnv, refetch, type, ...rest }) => {


### PR DESCRIPTION
`internal_container_registry` has been removed from core since 2.28.0. This removes it from this UI as it has already been removed from the old UI.

The option is no longer available in the drop down, preventing users from getting an error if they attempted to use it.

<img width="384" height="618" alt="image" src="https://github.com/user-attachments/assets/2bbd140d-15f1-4308-a63d-9f40df044b76" />


Closes #70 