### PR TITLE
feat: use code block for logs

### DIFF
--- a/src/components/logViewer/LogViewer.tsx
+++ b/src/components/logViewer/LogViewer.tsx
@@ -67,7 +67,7 @@ const LogViewer: FC<LogViewerProps> = ({
           </div>
         ) : (
           <div className="text-[14px] leading-[18px] font-normal m-0 break-words  whitespace-pre-wrap will-change-auto break-all p-[10px]">
-            {logs}
+            <code>{logs}</code>
           </div>
         )
       ) : (
@@ -125,7 +125,7 @@ const logPreprocessor = (
           className="log-text text-[14px] leading-[18px] font-normal m-0 break-words whitespace-pre-wrap will-change-auto break-all"
           data-cy="log-text"
         >
-          {logs}
+          <code>{logs}</code>
         </div>
       </div>
     );
@@ -166,7 +166,7 @@ const LogNodeRenderer: React.FC<{
         ref={logsContentRef}
         className="log-text text-[14px] leading-[18px] font-normal m-0 break-words whitespace-pre-wrap will-change-auto break-all"
       >
-        {node.text}
+        <code>{node.text}</code>
       </div>
     );
   }


### PR DESCRIPTION
Just adds code blocks to the log views

<img width="601" height="464" alt="image" src="https://github.com/user-attachments/assets/cad8befd-2835-4312-8bd9-53c40d2023fd" />
