### PR TITLE
fix: use environment name in sidebar instead of namespace name

### DIFF
--- a/src/components/dynamicNavigation/DynamicNavigation.tsx
+++ b/src/components/dynamicNavigation/DynamicNavigation.tsx
@@ -45,7 +45,7 @@ export const getEnvironmentNav = (
 
   return [
     {
-      title: String(environmentData?.environment?.name),
+      title: String(environmentData?.environment?.name ? environmentData?.environment?.name : environmentSlug),
       url: `/projects/${projectSlug}/${environmentSlug}`,
       icon: GitPullRequestDraft,
       children: [


### PR DESCRIPTION
Changes the sidebar to use the environment name instead of the namespace name

Before:
<img width="389" height="503" alt="image" src="https://github.com/user-attachments/assets/9b1aa0d2-7553-47d0-8027-46b843d8bff5" />

After:
<img width="396" height="619" alt="image" src="https://github.com/user-attachments/assets/635189b6-83ad-46a1-bc19-0a6716a90d1b" />

Will check if the name exists and use it, otherwise falls back to the slug (namespace name)