### PR TITLE
chore: remove group-roles from users overview page

### DIFF
--- a/src/components/pages/organizations/users/UsersDataTableColumns.tsx
+++ b/src/components/pages/organizations/users/UsersDataTableColumns.tsx
@@ -69,21 +69,6 @@ const UsersDataTableColumns = (
     },
   },
   {
-    accessorKey: 'groupRoles',
-    header: 'Roles',
-    cell: ({ row }) => {
-      const groupRoles = row.original.groupRoles;
-
-      return (
-        <div className="flex flex-col gap-2">
-          {[...new Set(groupRoles.map(group => group.role))].map(uniqueRole => (
-            <Badge key={uniqueRole}>{uniqueRole}</Badge>
-          ))}
-        </div>
-      );
-    },
-  },
-  {
     id: 'Groups',
     accessorFn: row => row.groupRoles?.length,
     sortingFn: (rowA, rowB, columnId) => {


### PR DESCRIPTION
This removes the `roles` column from the org users overview page.

<img width="1474" height="589" alt="image" src="https://github.com/user-attachments/assets/bc3382f3-44b8-40d2-869a-170e150a2b53" />

This column is misleading, since a users role is derived from the group they are in, showing their "roles" in a consolidated view like this can lead people to believe they have a role on a project or group that they may not have.

If a user has maintainer in only 1 project, but developer in every other project, then it can lead to confusion that the user maybe has `maintainer` on more projects, but it doesn't show this clearly, the only way to then work out which role the user does have and how it is associated to them is by clicking on that user to view their access.
<img width="1480" height="433" alt="image" src="https://github.com/user-attachments/assets/65cad1f1-3c5d-493a-88f2-65be666d7adb" />

If there is a better way to visualise how those roles are associated to the user on the overview page, then maybe it can stay. Otherwise it should go.