### PR TITLE
Fix: Converts Checkbox value to an actual boolean

### DIFF
--- a/src/components/createProject/_components/AddProjectSheet.tsx
+++ b/src/components/createProject/_components/AddProjectSheet.tsx
@@ -24,6 +24,7 @@ const AddProjectSheet = ({
   const handleAddProject = async (e: React.MouseEvent<HTMLButtonElement>, values: any) => {
     try {
       const { projectName, gitUrl, prodEnv, deployTarget, branches, pullRequests, addUserToProject } = values;
+      const addUserToProjectBool = Boolean(addUserToProject);
 
       await addProjectMutation({
         variables: {
@@ -34,7 +35,7 @@ const AddProjectSheet = ({
           kubernetes: parseInt(deployTarget, 10),
           ...(pullRequests ? { pullrequests: pullRequests } : {}),
           ...(branches ? { branches: branches } : {}),
-          addOrgOwner: addUserToProject,
+          addOrgOwner: addUserToProjectBool,
         },
       });
     } catch (err) {


### PR DESCRIPTION
The current shadcn `Checkbox` component doesn't return a `boolean` as the value, resulting in errors for `addOrgOwner` when checked. This updates the value from a `string` to `boolean`.

https://ui.add-user-fix.lagoon-beta-ui.test6.amazee.io/organizations