### PR TITLE
Reverts core-treeish to `main`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CI_BUILD_TAG ?= lagoon-ui
 CORE_REPO=https://github.com/uselagoon/lagoon.git
 # CORE_REPO = ../lagoon
-CORE_TREEISH=api-defined-routes
+CORE_TREEISH=main
 
 # for the `stable` targets, images with these tags will be used
 LAGOON_CORE_IMAGE_REPO=testlagoon


### PR DESCRIPTION
#77 changed the makefile CORE_TREEISH definition to point to the `api-defined-routes` source for testing.
This likely should have been changed back to `main` before merging.
This PR reverts that change.