### PR TITLE
Fix: Active/standby & logviewer fixes

### DIFF
--- a/src/components/logViewer/LogViewer.tsx
+++ b/src/components/logViewer/LogViewer.tsx
@@ -226,7 +226,7 @@ const LogNodeRenderer: React.FC<{
       },
     ];
 
-    const accordion = <Accordion type="multiple" items={accordionItems} />;
+    const accordion = <Accordion type="multiple" items={accordionItems} defaultValue={visible ? [String(node.key)] : []} />;
 
     if (showSuccessSteps) {
       return accordion;

--- a/src/components/pages/deployment/DeploymentPage.tsx
+++ b/src/components/pages/deployment/DeploymentPage.tsx
@@ -19,6 +19,7 @@ import utc from 'dayjs/plugin/utc';
 import { getDeploymentDuration } from '../allDeployments/TableColumns';
 import {capitalize} from "@/components/utils";
 import {Loader2} from "lucide-react";
+import {getBadgeVariant} from "../../../../utils/setBadgeStatus";
 
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
@@ -98,7 +99,7 @@ export default function DeploymentPage({
   };
 
   const deploymentDataRow = {
-    status: <Badge variant="default">{capitalize(deployment.status)} {!['complete', 'cancelled', 'failed'].includes(deployment.status) &&
+    status: <Badge variant={getBadgeVariant(deployment.status, deployment.buildStep)}>{capitalize(deployment.status)} {!['complete', 'cancelled', 'failed'].includes(deployment.status) &&
       <Loader2 className="h-4 w-4 animate-spin t"/>}
     </Badge>,
     name: deployment.bulkId ? (

--- a/src/components/pages/environment/EnvironmentPage.tsx
+++ b/src/components/pages/environment/EnvironmentPage.tsx
@@ -10,7 +10,7 @@ import deleteEnvironment from '@/lib/mutation/deleteEnvironment';
 import switchActiveStandby from '@/lib/mutation/switchActiveStandby';
 import environmentByOpenShiftProjectNameWithFacts from '@/lib/query/environmentWIthInsightsAndFacts';
 import { QueryRef, useMutation, useQuery, useQueryRefHandlers, useReadQuery } from '@apollo/client';
-import { DetailStat } from '@uselagoon/ui-library';
+import {Badge, DetailStat} from '@uselagoon/ui-library';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import gitUrlParse from 'git-url-parse';
@@ -20,6 +20,7 @@ import DeleteConfirm from '../../deleteConfirm/DeleteConfirm';
 import KeyFacts from './_components/KeyFacts';
 import LimitedRoutes from './_components/LimitedRoutes';
 import deduplicateFacts from './_components/deduplicateFacts';
+import {makeSafe} from "@/components/utils";
 
 dayjs.extend(utc);
 
@@ -94,9 +95,34 @@ export default function EnvironmentPage({
 
   const keyFacts = deduplicateFacts(environmentFacts);
 
+  const activeEnvironment =
+    environment.project.productionEnvironment &&
+    environment.project.standbyProductionEnvironment &&
+    environment.project.productionEnvironment == makeSafe(environment.name);
+  const standbyEnvironment =
+    environment.project.productionEnvironment &&
+    environment.project.standbyProductionEnvironment &&
+    environment.project.standbyProductionEnvironment == makeSafe(environment.name);
+
   const environmentDetailItems = [
     {
-      children: environment.environmentType,
+      children: (
+        <div className="flex items-center">
+          <span className="capitalize">{environment.environmentType}</span>
+            <>
+              { activeEnvironment ? (
+                <Badge variant="success" className="ml-2">
+                  Active
+                </Badge>
+              ) : null}
+              { standbyEnvironment ? (
+                <Badge variant="lagoon" className="ml-2">
+                  Standby
+                </Badge>
+              ) : null}
+            </>
+        </div>
+      ),
       key: 'env_type',
       title: 'Environment type',
       lowercaseValue: true,
@@ -187,21 +213,32 @@ export default function EnvironmentPage({
       <section className="mt-10 [&>*:not(:first-child)]:mb-2">
         <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight mb-5">Routes</h3>
 
-        <div className="flex justify-start gap-24">
-          {routes ? (
-            <section>
-              <h4 className="scroll-m-20 text-md font-semibold tracking-tight mb-3">Active routes</h4>
-              <LimitedRoutes routes={routes} />
-            </section>
+        <div className="flex justify-start gap-34">
+          {activeEnvironment && activeRoutes ? (
+            <>
+              <section>
+                <h4 className="scroll-m-20 text-md font-semibold tracking-tight mb-3">Active routes</h4>
+                <LimitedRoutes routes={activeRoutes} />
+              </section>
+              <br />
+            </>
           ) : null}
 
-          <br />
-          {standbyRoutes ? (
-            <section>
-              <h5 className="scroll-m-20 text-md font-semibold tracking-tight mb-3">Standby routes</h5>
-              <LimitedRoutes routes={standbyRoutes} />
-            </section>
+          {standbyEnvironment && standbyRoutes ? (
+            <>
+              <section>
+                <h4 className="scroll-m-20 text-md font-semibold tracking-tight mb-3">Standby routes</h4>
+                <LimitedRoutes routes={standbyRoutes} />
+              </section>
+              <br />
+            </>
           ) : null}
+          {routes && (
+              <section>
+                <h4 className="scroll-m-20 text-md font-semibold tracking-tight mb-3">Routes</h4>
+                <LimitedRoutes routes={routes} />
+              </section>
+          )}
         </div>
         {envHasNoRoutes && (
           <span className="text-[#737373] inline-block font-sans font-normal not-italic text-sm leading-normal tracking-normal">


### PR DESCRIPTION
Addresses a few issues with how Active Standby details & Logs are displayed.

- Updates the displayed routes to render the correct routes for `active/standby` environments
- Adds a small `Badge` on `EnvironmentType` to show `active/standby` environments
- Properly applies variants to `Badges` in the `LogViewer`
- Fixes the `LogViewer` to actually expand the last build step by default

https://ui.as-ui-improvements.lagoon-beta-ui.test6.amazee.io/projects

<details>
<summary><strong>Screenshots</strong></summary>

<img width="1193" height="584" alt="2025-11-25_15-37" src="https://github.com/user-attachments/assets/c198fbdd-88d7-449b-b740-9b663a02e243" />
<img width="1031" height="509" alt="2025-11-25_15-37_1" src="https://github.com/user-attachments/assets/ffa5f46a-bac8-419d-be47-59a1f0a1d391" />
<img width="750" height="433" alt="2025-11-25_15-51" src="https://github.com/user-attachments/assets/8da9941d-eec7-4e3a-b2c5-a4fdaf9324e6" />
<img width="781" height="468" alt="2025-11-25_15-51_1" src="https://github.com/user-attachments/assets/84158082-d35a-4260-a7f4-5d4be5d7f2fa" />
<img width="596" height="347" alt="2025-11-25_15-59" src="https://github.com/user-attachments/assets/238be774-3c7c-48c6-835f-2997c53017c6" />
<img width="642" height="276" alt="2025-11-25_15-59_1" src="https://github.com/user-attachments/assets/ff596b53-1ed0-4437-bb0f-0c080a864a68" />
<img width="1317" height="682" alt="2025-11-25_16-46" src="https://github.com/user-attachments/assets/e344e119-5fd6-40a1-83e7-5a95459c45e9" />

