### PR TITLE
Change: Includes standby production environments in environment sorting

### DIFF
--- a/src/components/pages/environments/ProjectEnvironmentsPage.tsx
+++ b/src/components/pages/environments/ProjectEnvironmentsPage.tsx
@@ -55,22 +55,24 @@ export default function ProjectEnvironmentsPage({
   };
   const { environments } = project;
   const productionEnvironment = project.productionEnvironment;
+  const standbyProductionEnvironment = project.standbyProductionEnvironment;
 
   const sortedEnvironments = [
     environments.find(env => makeSafe(env.name) === productionEnvironment),
-    ...environments.filter(env => makeSafe(env.name) !== productionEnvironment),
+    standbyProductionEnvironment && environments.find(env => makeSafe(env.name) === standbyProductionEnvironment),
+    ...environments.filter(env => makeSafe(env.name) !== productionEnvironment && makeSafe(env.name) !== standbyProductionEnvironment),
   ].filter(env => !!env);
 
   const envTableData = sortedEnvironments.map(environment => {
 
     const activeEnvironment =
-      project.productionEnvironment &&
-      project.standbyProductionEnvironment &&
-      project.productionEnvironment == makeSafe(environment.name);
+      productionEnvironment &&
+      standbyProductionEnvironment &&
+      productionEnvironment == makeSafe(environment.name);
     const standbyEnvironment =
-      project.productionEnvironment &&
-      project.standbyProductionEnvironment &&
-      project.standbyProductionEnvironment == makeSafe(environment.name);
+      productionEnvironment &&
+      standbyProductionEnvironment &&
+      standbyProductionEnvironment == makeSafe(environment.name);
 
     const envType = activeEnvironment
       ? 'active production'


### PR DESCRIPTION
Currently standby production environments are not included when sorting environments to be displayed in the `DataTable`. This simply updates `sortedEnvironments` to include the standby production environment.

<img width="1368" height="422" alt="image" src="https://github.com/user-attachments/assets/4cd2ebae-63f1-480e-a5ed-3bd70c5325c7" />