### PR TITLE
Fix: Sets inputDefault to Booleans for Project & User Sheets

### DIFF
--- a/src/components/addUserToOrg/AddUserSheet.tsx
+++ b/src/components/addUserToOrg/AddUserSheet.tsx
@@ -88,7 +88,7 @@ const AddUserSheet = ({
             id: 'inviteUser',
             label: 'Invite user to Lagoon',
             type: 'checkbox',
-            inputDefault: 'true',
+            inputDefault: true,
           },
         ]}
         additionalContent={

--- a/src/components/createProject/_components/AddProjectSheet.tsx
+++ b/src/components/createProject/_components/AddProjectSheet.tsx
@@ -156,7 +156,7 @@ const AddProjectSheet = ({
             id: 'addUserToProject',
             label: 'Add my user to this project',
             type: 'checkbox',
-            inputDefault: 'true',
+            inputDefault: true,
           },
         ]}
       />


### PR DESCRIPTION
The `Checkbox` default values for `AddProjectSheet` & `AddUserSheet` are currently `strings`, resulting in errors when using their default state. The `Sheet` component in the UI-Library was recently updated to accept `boolean` values for `inputDefault`, this updates those values from `strings` to `booleans`.