### PR TITLE
Fix: Pending changes toast closure & Textarea for variable values

### DIFF
--- a/src/components/addNewVariable/AddNewVariable.tsx
+++ b/src/components/addNewVariable/AddNewVariable.tsx
@@ -120,6 +120,7 @@ export const AddNewVariable: FC<Props> = ({ type, refetch, onClick, ...rest }) =
           id: 'variable_value',
           label: 'Variable value',
           placeholder: 'Enter variable value',
+          type: 'textarea',
           required: true,
         },
       ]}

--- a/src/components/pages/projectVariables/_components/EditVariable.tsx
+++ b/src/components/pages/projectVariables/_components/EditVariable.tsx
@@ -131,6 +131,7 @@ export const EditVariable: FC<Props> = ({ currentEnv, refetch, type, ...rest }) 
                 id: 'variable_value',
                 label: 'Variable value',
                 placeholder: 'Enter variable value',
+                type: 'textarea',
                 inputDefault: currentEnv.value,
                 required: true,
               },

--- a/src/hooks/usePendingChangesNotification.tsx
+++ b/src/hooks/usePendingChangesNotification.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { toast } from 'sonner';
+import {X} from "lucide-react";
 
 interface PendingChange {
   details: string;
@@ -40,12 +41,7 @@ export const usePendingChangesNotification = (options: UsePendingChangesNotifica
       toast.custom(
         (t) => (
           <div 
-            className="flex items-center gap-3 p-4 border border-sky-500 rounded-lg shadow-lg min-w-80 max-w-md"
-            style={{ 
-              backgroundColor: '#CFEDFB',
-              color: '#000000'
-            }}
-          >
+            className="flex items-center gap-3 p-4 border border-sky-500 rounded-lg shadow-lg min-w-80 max-w-md bg-[#CFEDFB] text-black mt-4">
             <div className="flex-1">
               <p className="font-medium text-sm whitespace-nowrap">
                 Changes require deployment to take effect
@@ -59,6 +55,9 @@ export const usePendingChangesNotification = (options: UsePendingChangesNotifica
               className="px-3 py-1 bg-sky-500 text-white rounded text-sm font-medium hover:bg-sky-600 transition-colors whitespace-nowrap pending-changes-notification__deploy-button"
             >
               Deploy now
+            </button>
+            <button onClick={() => toast.dismiss(t)} className="text-gray-500 hover:text-gray-700 transition-colors" aria-label="Close">
+              <X size={18} />
             </button>
           </div>
         ),


### PR DESCRIPTION
Allows the pending changes `Toast` to be closed as it was obstructing content on some pages. Also updates the field for variable values from an `Input` to a `Textarea` to allow for multiline values.

https://ui.pr-110.lagoon-beta-ui.test1.amazee.io/