### PR TITLE
Docs: Updates release link to 2.30.0

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -2,5 +2,8 @@
   "global": {
   },
   "components": {
+    "announcementCard": {
+      "ctaUrl": "https://docs.lagoon.sh/releases/2.30.0/"
+    }
   }
 }


### PR DESCRIPTION
Updates the release link to `2.30.0` via component overrides. This is a temporary solution until the Activity Log is implemented.