### PR TITLE
Change: Adds time tooltip for task log

### DIFF
--- a/src/components/pages/task/TaskPage.tsx
+++ b/src/components/pages/task/TaskPage.tsx
@@ -8,7 +8,7 @@ import TaskNotFound from '@/components/errors/TaskNotFound';
 import { getTaskDuration } from '@/components/utils';
 import getTaskFilesDownload from '@/lib/query/getTaskFileDownload';
 import { QueryRef, useLazyQuery, useQueryRefHandlers, useReadQuery } from '@apollo/client';
-import { Badge, BasicTable, Button, Switch } from '@uselagoon/ui-library';
+import {Badge, BasicTable, Button, Switch, Tooltip, TooltipContent, TooltipTrigger} from '@uselagoon/ui-library';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import utc from 'dayjs/plugin/utc';
@@ -152,10 +152,17 @@ export default function TaskPage({ queryRef, taskName }: { queryRef: QueryRef<Ta
   if (!environment?.tasks.length) {
     return <TaskNotFound taskName={taskName} />;
   }
+
+  let createdTooltip =
+    <Tooltip>
+      <TooltipTrigger>{dayjs.utc(currentTask.created).local().fromNow()}</TooltipTrigger>
+      <TooltipContent>{dayjs.utc(currentTask.created).local().format('YYYY-MM-DD HH:mm:ss')}</TooltipContent>
+    </Tooltip>
+
   const taskDataRow = {
     name: currentTask.name,
     service: currentTask.service,
-    created: dayjs.utc(currentTask.created).local().fromNow(),
+    created: createdTooltip,
     duration: getTaskDuration(currentTask),
     status: <Badge variant="default">{currentTask.status}</Badge>,
 


### PR DESCRIPTION
A `tooltip` showing the exact time is available on hover for the `Timestamp` column in the Tasks page. This PR adds the same `tooltip` to the Task page.

https://ui.add-time-tooltip.lagoon-beta-ui.test6.amazee.io/projects/drupal-example/drupal-example-master/tasks/lagoon-task-p62odq

<details>
<summary>Screenshots</summary>
<img width="824" height="320" alt="2026-01-22_09-53" src="https://github.com/user-attachments/assets/61e23c7d-671c-4ecf-aaeb-f08728e06cd3" />
<img width="824" height="639" alt="2026-01-22_09-30" src="https://github.com/user-attachments/assets/eb1c2215-6c45-43a4-84c8-ae9e63670927" />
</details>
