### PR TITLE
chore: enable multiarch images for main

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -97,8 +97,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          # platforms: linux/amd64,linux/arm64
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             "LAGOON_VERSION=${{ env.VERSION }}"
             "BUILD=${{ env.BUILD }}"


### PR DESCRIPTION
Enables arm image builds

Edit: This seems like it might be a bad idea :grimacing: this isn't the most efficient docker image build when its just `amd64`

closes #125 