### PR TITLE
Preserve intended URL after login redirect

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -47,12 +47,15 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     async authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user;
       const isOnLogin = nextUrl.pathname === '/api/login';
+
       if (isOnLogin) return true;
+
       if (!isLoggedIn) {
         const loginUrl = new URL('/api/login', nextUrl);
         loginUrl.searchParams.set('callbackUrl', nextUrl.pathname + nextUrl.search);
         return Response.redirect(loginUrl);
       }
+      
       return true;
     },
     async jwt({ token, account }: { token: JWT; account?: Account | null | undefined }): Promise<JWT> {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -44,9 +44,16 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     strategy: 'jwt',
   },
   callbacks: {
-    async authorized({ auth }) {
-      // Logged in users are authenticated, otherwise redirect to login page
-      return !!auth;
+    async authorized({ auth, request: { nextUrl } }) {
+      const isLoggedIn = !!auth?.user;
+      const isOnLogin = nextUrl.pathname === '/api/login';
+      if (isOnLogin) return true;
+      if (!isLoggedIn) {
+        const loginUrl = new URL('/api/login', nextUrl);
+        loginUrl.searchParams.set('callbackUrl', nextUrl.pathname + nextUrl.search);
+        return Response.redirect(loginUrl);
+      }
+      return true;
     },
     async jwt({ token, account }: { token: JWT; account?: Account | null | undefined }): Promise<JWT> {
       if (account) {


### PR DESCRIPTION
## Summary
- When unauthenticated users visit a deep link (e.g. `/project/123`), they are now redirected back to the original URL after signing in, instead of landing on `/`
- The `authorized` callback in `src/auth.ts` now explicitly passes the original path as a `callbackUrl` search param to the `/api/login` route

Fixes #109

## Test plan
- [ ] Visit a deep link (e.g. `/projects/some-project`) while logged out
- [ ] Verify you are redirected to Keycloak login
- [ ] After signing in, verify you land on the original URL, not `/`
- [ ] Verify normal login flow (visiting `/` or `/projects`) still works