### PR TITLE
Fix: Fixes premature Sheet closure on variable edit

### DIFF
--- a/src/components/pages/projectVariables/_components/EditVariable.tsx
+++ b/src/components/pages/projectVariables/_components/EditVariable.tsx
@@ -139,6 +139,7 @@ export const EditVariable: FC<Props> = ({ currentEnv, refetch, type, additionalC
             ]}
             buttonAction={(_, { variable_name, variable_scope, variable_value }) => {
               handleUpdateVariable(variable_name, variable_scope, variable_value);
+              return false;
             }}
           />
         </TooltipTrigger>


### PR DESCRIPTION
Currently when updating a variable the `Sheet` closes on submit, the mutation fires and refetches the components. If the user tries to interact with another element during this brief window the element state will reset on refetch, which can cause open `Sheets` to close etc. 

This fixes the premature `Sheet` closure on submit, having it instead watch the `loading` prop for closure - so the `Sheet` now only closes once the mutation completes.