### PR TITLE
Fix: Displays the actual latest deployment rather than the env update time

### DIFF
--- a/src/app/(routegroups)/(projectroutes)/projects/(projects-page)/page.tsx
+++ b/src/app/(routegroups)/(projectroutes)/projects/(projects-page)/page.tsx
@@ -24,7 +24,7 @@ export type ProjectType = {
       name: string;
       route: string;
       updated: string;
-      latestDeployment?: Deployment;
+      deployments?: Deployment[];
       kubernetes: {
         id: number;
         name: string;

--- a/src/app/(routegroups)/(projectroutes)/projects/(projects-page)/page.tsx
+++ b/src/app/(routegroups)/(projectroutes)/projects/(projects-page)/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next';
 import ProjectsPage from '@/components/pages/projects/ProjectsPage';
 import { getClient } from '@/lib/apolloClient';
 import allProjectsQuery from '@/lib/query/allProjectsQuery';
+import { Deployment } from '../[projectSlug]/[environmentSlug]/deployments/[deploymentSlug]/page';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,6 +24,7 @@ export type ProjectType = {
       name: string;
       route: string;
       updated: string;
+      latestDeployment?: Deployment;
       kubernetes: {
         id: number;
         name: string;

--- a/src/app/(routegroups)/(projectroutes)/projects/[projectSlug]/(project-overview)/page.tsx
+++ b/src/app/(routegroups)/(projectroutes)/projects/[projectSlug]/(project-overview)/page.tsx
@@ -27,7 +27,6 @@ export type ProjectEnvironment = {
   problems: Problem[];
   deployments: Deployment[];
   pendingChanges: Array<{ details: string }>;
-  latestDeployment?: Deployment;
 };
 
 type Project = {

--- a/src/app/(routegroups)/(projectroutes)/projects/[projectSlug]/(project-overview)/page.tsx
+++ b/src/app/(routegroups)/(projectroutes)/projects/[projectSlug]/(project-overview)/page.tsx
@@ -27,6 +27,7 @@ export type ProjectEnvironment = {
   problems: Problem[];
   deployments: Deployment[];
   pendingChanges: Array<{ details: string }>;
+  latestDeployment?: Deployment;
 };
 
 type Project = {

--- a/src/components/pages/environments/ProjectEnvironmentsPage.tsx
+++ b/src/components/pages/environments/ProjectEnvironmentsPage.tsx
@@ -93,7 +93,7 @@ export default function ProjectEnvironmentsPage({
       deployType: environment.deployType,
       activeRoutes: <RoutesWrapper>{createLinks(routesToUse)}</RoutesWrapper>,
       envType: envType as any,
-      last_deployment: environment.latestDeployment?.created ?? '',
+      last_deployment: environment.deployments?.[0]?.created ?? '',
       region: environment.openshift?.cloudRegion ?? '',
       project: environment.project,
     };

--- a/src/components/pages/environments/ProjectEnvironmentsPage.tsx
+++ b/src/components/pages/environments/ProjectEnvironmentsPage.tsx
@@ -93,7 +93,7 @@ export default function ProjectEnvironmentsPage({
       deployType: environment.deployType,
       activeRoutes: <RoutesWrapper>{createLinks(routesToUse)}</RoutesWrapper>,
       envType: envType as any,
-      last_deployment: environment.updated ?? '',
+      last_deployment: environment.latestDeployment?.created ?? '',
       region: environment.openshift?.cloudRegion ?? '',
       project: environment.project,
     };

--- a/src/components/pages/projects/DataTableColumns.tsx
+++ b/src/components/pages/projects/DataTableColumns.tsx
@@ -14,7 +14,7 @@ dayjs.extend(relativeTime);
 
 const getLatestDate = (environments: ProjectType['environments']) => {
   return environments
-    .map(env => env.latestDeployment?.created)
+    .map(env => env.deployments?.[0]?.created)
     .filter(date => date != null)
     .sort()
     .pop();

--- a/src/components/pages/projects/DataTableColumns.tsx
+++ b/src/components/pages/projects/DataTableColumns.tsx
@@ -14,7 +14,7 @@ dayjs.extend(relativeTime);
 
 const getLatestDate = (environments: ProjectType['environments']) => {
   return environments
-    .map(env => env.updated)
+    .map(env => env.latestDeployment?.created)
     .filter(date => date != null)
     .sort()
     .pop();

--- a/src/lib/query/allProjectsQuery.ts
+++ b/src/lib/query/allProjectsQuery.ts
@@ -13,7 +13,7 @@ export default gql`
       environments(type: PRODUCTION) {
         name
         route
-        latestDeployment {
+        deployments(limit: 1) {
           created
         }
         kubernetes {

--- a/src/lib/query/allProjectsQuery.ts
+++ b/src/lib/query/allProjectsQuery.ts
@@ -13,7 +13,9 @@ export default gql`
       environments(type: PRODUCTION) {
         name
         route
-        updated
+        latestDeployment {
+          created
+        }
         kubernetes {
           id
           name

--- a/src/lib/query/projectEnvironmentsQuery.ts
+++ b/src/lib/query/projectEnvironmentsQuery.ts
@@ -15,7 +15,7 @@ export default gql`
         deployType
         environmentType
         routes
-        latestDeployment {
+        deployments(limit: 1) {
           created
         }
         openshiftProjectName

--- a/src/lib/query/projectEnvironmentsQuery.ts
+++ b/src/lib/query/projectEnvironmentsQuery.ts
@@ -15,7 +15,9 @@ export default gql`
         deployType
         environmentType
         routes
-        updated
+        latestDeployment {
+          created
+        }
         openshiftProjectName
         project {
           problemsUi


### PR DESCRIPTION
Currently the Last Deploy field column in the UI uses the environment `updated` time, instead of the latest deployment. This updates the column to use `deployments(limit: 1)` to source the correct data.

https://ui.last-deployment-fix.lagoon-beta-ui.test6.amazee.io/