### PR TITLE
Feat: Project clone organization deploy keys

### DIFF
--- a/src/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/(organization-overview)/page.tsx
+++ b/src/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/(organization-overview)/page.tsx
@@ -24,10 +24,10 @@ export type OrgProject = {
   id: number;
   name: string;
   groupCount?: number;
-  gitUrl?: string;
   clone?: {
     status: string;
   };
+  organizationKey?: number;
 };
 
 export type OrgGroup = {

--- a/src/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/loading.tsx
+++ b/src/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/loading.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import React from 'react';
+
+import SectionWrapper from '@/components/SectionWrapper/SectionWrapper';
+import KeysDataTableColumns from '@/components/pages/organizations/keys/KeysDataTableColumns';
+import { DataTable, Skeleton } from '@/ui-library';
+
+export default function Loading() {
+  return (
+    <SectionWrapper>
+      <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">Organization Keys</h3>
+      <div className="flex gap-4 items-center">
+        <span className="inline-block my-4 mr-4">Create a new key</span>
+        <Skeleton className="h-8 w-[100px]" />
+      </div>
+      <DataTable loading columns={KeysDataTableColumns()} data={[]} />
+    </SectionWrapper>
+  );
+}

--- a/src/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/page.tsx
+++ b/src/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/page.tsx
@@ -1,0 +1,59 @@
+import KeysPage from '@/components/pages/organizations/keys/KeysPage';
+import { PreloadQuery } from '@/lib/apolloClient';
+import organizationByNameKeys from '@/lib/query/organizations/organizationByName.keys';
+import { QueryRef } from '@apollo/client';
+import { OrgProject } from '../(organization-overview)/page';
+
+type Props = {
+  params: Promise<{ organizationSlug: string }>;
+};
+
+type Organization = {
+  id: number;
+  name: string;
+  friendlyName?: string;
+  projects: OrgProject[];
+  keys: OrganizationKey[];
+};
+
+export type OrganizationKey = {
+  id: number;
+  name: string;
+  publicKey: string;
+  privateKey: string;
+  projects: OrgProject[];
+  comment: string;
+  created: string;
+}
+
+export interface OrganizationKeysData {
+  organization: Organization;
+}
+
+export async function generateMetadata(props: Props) {
+  const params = await props.params;
+  return {
+    title: `${params.organizationSlug} | Organization`,
+  };
+}
+
+export default async function OrganizationKeys(props: { params: Promise<{ organizationSlug: string }> }) {
+  const params = await props.params;
+
+  const { organizationSlug } = params;
+
+  return (
+    <PreloadQuery
+      query={organizationByNameKeys}
+      variables={{
+        displayName: 'Organization',
+        name: organizationSlug,
+        limit: null,
+      }}
+    >
+      {queryRef => (
+        <KeysPage organizationSlug={organizationSlug} queryRef={queryRef as QueryRef<OrganizationKeysData>} />
+      )}
+    </PreloadQuery>
+  );
+}

--- a/src/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/projects/(projects-page)/loading.tsx
+++ b/src/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/projects/(projects-page)/loading.tsx
@@ -18,11 +18,11 @@ export default function Loading() {
         </div>
         <DataTable
           loading
-          columns={ProjectsDataTableColumns((_: OrgProject) => null, '', false)}
+          columns={ProjectsDataTableColumns((_: OrgProject) => null, '', false, [])}
           data={[]}
           searchableColumns={['name']}
           initialPageSize={10}
-          renderFilters={table => (
+          renderFilters={() => (
             <div className="flex items-center justify-between">
               <SelectWithOptions
                 options={resultsFilterValues.map(o => ({ label: o.label, value: o.value }))}

--- a/src/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/projects/(projects-page)/page.tsx
+++ b/src/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/projects/(projects-page)/page.tsx
@@ -4,6 +4,7 @@ import organizationByNameProjects from '@/lib/query/organizations/organizationBy
 import { QueryRef } from '@apollo/client';
 
 import { DeployTarget, OrgProject } from '../../(organization-overview)/page';
+import { OrganizationKey } from '../../keys/page';
 
 type Props = {
   params: Promise<{ organizationSlug: string }>;
@@ -17,6 +18,7 @@ export type OrganizationProjectsData = {
     projects: OrgProject[];
     deployTargets: DeployTarget[];
     featureProjectClone: boolean;
+    keys: OrganizationKey[];
   };
 };
 

--- a/src/components/addOrgKeyToProject/AddOrgKeyToProject.tsx
+++ b/src/components/addOrgKeyToProject/AddOrgKeyToProject.tsx
@@ -1,0 +1,82 @@
+import { FC, startTransition } from 'react';
+
+import addOrganizationKeyToProject from '@/lib/mutation/organizations/addOrganizationKeyToProject';
+import { OrgProject } from '@/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/(organization-overview)/page';
+import { ApolloError, useMutation } from '@apollo/client';
+import { Key } from 'lucide-react';
+import { Sheet } from '@/ui-library';
+import { toast } from 'sonner';
+
+type Props = {
+  keyId: number;
+  keyName?: string;
+  projects: OrgProject[];
+  disabled?: boolean;
+  refetch?: () => void;
+};
+
+/**
+ * Add organization key to project sheet.
+ */
+export const AddOrganizationKeyToProject: FC<Props> = ({ keyId, keyName, projects, disabled = false, refetch }) => {
+  const [addOrganizationKeyToProjectMutation, { error, loading }] = useMutation(addOrganizationKeyToProject, {
+    refetchQueries: ['getOrganization'],
+  });
+
+  const handleAddKeyToProject = async (_e: React.MouseEvent<HTMLButtonElement>, values: any) => {
+    try {
+      const { project } = values;
+      await addOrganizationKeyToProjectMutation({
+        variables: {
+          id: keyId,
+          project,
+        },
+      });
+      toast.success(`Key added to project ${project} successfully!`);
+      startTransition(() => {
+        refetch && refetch();
+      });
+    } catch (err) {
+      console.error(err);
+      toast.error(`There was a problem adding key to project.`, {
+        id: 'project_key_error',
+        description: (err as ApolloError).message,
+      });
+      return false;
+    }
+  };
+
+  const projectOptions = projects
+    .filter(proj => !proj.clone || (proj.clone.status !== 'FAILED' && proj.clone.status !== 'CANCELLED'))
+    .map(proj => ({ label: proj.name, value: proj.name }));
+
+  return (
+    <Sheet
+      disabled={disabled || projectOptions.length === 0}
+      sheetTrigger={<Key className="h-5 w-5" />}
+      sheetTitle={keyName ? `Add key "${keyName}" to a project` : 'Add key to a project'}
+      sheetDescription="Select a project to assign this key to."
+      sheetFooterButton="Confirm"
+      loading={loading}
+      error={!!error}
+      buttonAction={handleAddKeyToProject}
+      additionalContent={
+        error ? (
+          <div className="text-red-500 p-3 border border-red-300 rounded-md mt-2 bg-red-50">
+            <strong>Error:</strong> {error.message}
+          </div>
+        ) : null
+      }
+      sheetFields={[
+        {
+          id: 'project',
+          label: 'Project',
+          required: true,
+          placeholder: 'Select a project',
+          type: 'select',
+          options: projectOptions,
+        },
+      ]}
+    />
+  );
+};

--- a/src/components/cloneProject/CloneProject.tsx
+++ b/src/components/cloneProject/CloneProject.tsx
@@ -14,7 +14,7 @@ import { Copy } from 'lucide-react';
 import { ConfigureStep } from './_components/ConfigureStep';
 import { ErrorStep, ProgressStep, SuccessStep } from './_components/ResultSteps';
 import { CloneOptions, CLONE_OPTIONS_CONFIG, DialogStep, Environment, NAME_PATTERN, validateName } from './_components/types';
-
+import { OrganizationKey } from '@/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/page';
 export type { CloneOptions } from './_components/types';
 
 interface CloneProjectProps {
@@ -24,9 +24,10 @@ interface CloneProjectProps {
   onCloned?: (newProjectName: string) => void;
   toggleText?: boolean;
   disabled?: boolean;
+  keys: OrganizationKey[];
 }
 
-export const CloneProject: FC<CloneProjectProps> = ({ projectName, organizationSlug, refetch, onCloned, toggleText = false, disabled = false }) => {
+export const CloneProject: FC<CloneProjectProps> = ({ projectName, organizationSlug, refetch, onCloned, toggleText = false, disabled = false, keys = [] }) => {
   // TODO: find a better way to manage all this state
   const [isOpen, setIsOpen] = useState(false);
   const [step, setStep] = useState<DialogStep>('configure');
@@ -36,6 +37,8 @@ export const CloneProject: FC<CloneProjectProps> = ({ projectName, organizationS
   const [selectedEnvironment, setSelectedEnvironment] = useState('');
   const [clonedProjectName, setClonedProjectName] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [selectedKey, setSelectedKey] = useState<string>('');
+  const [keyAdded, setKeyAdded] = useState(false);
   const [options, setOptions] = useState<CloneOptions>({
     copyData: true,
     metadata: true,
@@ -117,12 +120,16 @@ export const CloneProject: FC<CloneProjectProps> = ({ projectName, organizationS
       environmentVariables: true,
     });
     setStep('configure');
+    setSelectedKey('');
+    setKeyAdded(false);
   };
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
     if (open) {
       fetchEnvironments();
+    } else if (keyAdded) {
+      refetch?.();
     }
     resetForm();
   };
@@ -158,7 +165,7 @@ export const CloneProject: FC<CloneProjectProps> = ({ projectName, organizationS
   };
 
   const handleClose = () => {
-    setIsOpen(false);
+    handleOpenChange(false);
   };
 
   const isNameValid = newProjectName.trim().length > 0 && NAME_PATTERN.test(newProjectName.trim());
@@ -195,6 +202,11 @@ export const CloneProject: FC<CloneProjectProps> = ({ projectName, organizationS
             isFormValid={isFormValid}
             onClone={handleClone}
             onClose={handleClose}
+            organizationSlug={organizationSlug}
+            keys={keys}
+            selectedKey={selectedKey}
+            setSelectedKey={setSelectedKey}
+            onKeyAdded={() => setKeyAdded(true)}
           />
         )}
 

--- a/src/components/cloneProject/_components/ConfigureStep.tsx
+++ b/src/components/cloneProject/_components/ConfigureStep.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 
 import {
   Alert,
@@ -16,9 +16,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/ui-library';
-import { AlertCircle, Info, Loader2 } from 'lucide-react';
+import { AlertTriangle, Info, Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { useMutation } from '@apollo/client';
 
+import addOrganizationKeyToProject from '@/lib/mutation/organizations/addOrganizationKeyToProject';
 import { CloneOptions, CLONE_OPTIONS_CONFIG, validateName } from './types';
+import { OrganizationKey } from '@/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/page';
 
 interface EnvironmentOption {
   label: string;
@@ -43,6 +47,11 @@ interface ConfigureStepProps {
   isFormValid: boolean;
   onClone: () => void;
   onClose: () => void;
+  organizationSlug?: string;
+  keys: OrganizationKey[];
+  selectedKey: string;
+  setSelectedKey: (value: string) => void;
+  onKeyAdded?: () => void;
 }
 
 export const ConfigureStep: FC<ConfigureStepProps> = ({
@@ -63,14 +72,47 @@ export const ConfigureStep: FC<ConfigureStepProps> = ({
   isFormValid,
   onClone,
   onClose,
+  organizationSlug,
+  keys,
+  selectedKey,
+  setSelectedKey,
+  onKeyAdded,
 }) => {
   const allChecked = CLONE_OPTIONS_CONFIG.every(({ key }) => options[key]);
   const someChecked = CLONE_OPTIONS_CONFIG.some(({ key }) => options[key]);
+
+  const [keyStatus, setkeyStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [keyError, setkeyError] = useState<string>('');
+
+  const [addKeyToProjectMutation, { loading: keyLoading }] = useMutation(addOrganizationKeyToProject);
 
   const handleToggleAll = () => {
     const next = !allChecked;
     setOptions(prev => Object.fromEntries(Object.keys(prev).map(k => [k, next])) as unknown as typeof prev);
   };
+
+  const handleAddKey = async () => {
+    if (!selectedKey) return;
+    setkeyStatus('idle');
+    setkeyError('');
+    try {
+      await addKeyToProjectMutation({
+        variables: {
+          id: Number(selectedKey),
+          project: projectName,
+        },
+      });
+      setkeyStatus('success');
+      onKeyAdded?.();
+    } catch (err) {
+      const message = (err as { message?: string })?.message ?? 'Unknown error';
+      setkeyStatus('error');
+      setkeyError(message);
+    }
+  };
+
+  const selectedKeyName = keys.find(key => String(key.id) === selectedKey)?.name ?? '';
+  const sourceProjectHasKey = keys.some(key => key.projects?.some(proj => proj.name === projectName));
 
   return (
     <>
@@ -146,6 +188,82 @@ export const ConfigureStep: FC<ConfigureStepProps> = ({
           )}
         </div>
 
+        <div className="space-y-2">
+          <p className="text-sm font-medium">
+            Add your Organization key (private repositories only)
+          </p>
+          <div className="flex items-center gap-2">
+            <div className="flex-1">
+              <SelectWithOptions
+                placeholder={keys.length > 0 ? 'Select an organization key' : 'No keys available'}
+                options={keys.map(key => ({ label: key.name, value: key.id }))}
+                value={selectedKey}
+                disabled={sourceProjectHasKey}
+                onValueChange={value => {
+                  setSelectedKey(value);
+                  setkeyStatus('idle');
+                  setkeyError('');
+                }}
+              />
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!selectedKey || keyLoading || sourceProjectHasKey}
+              onClick={handleAddKey}
+            >
+              {keyLoading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  Adding...
+                </>
+              ) : (
+                'Add Key'
+              )}
+            </Button>
+            {selectedKey && keyStatus !== 'success' && !sourceProjectHasKey && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertTriangle className="h-5 w-5 text-yellow-500 cursor-help flex-shrink-0" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  You have selected a key but haven&apos;t added it to the project yet. Click &ldquo;Add Key&rdquo; before cloning.
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+          {sourceProjectHasKey && (
+            <p className="text-sm text-muted-foreground">
+              This project already has an organization key assigned.
+            </p>
+          )}
+          {keyStatus === 'success' && (
+            <p className="text-sm text-green-600">
+              Key &ldquo;{selectedKeyName}&rdquo; added to {projectName}.
+            </p>
+          )}
+          {keyStatus === 'error' && (
+            <p className="text-sm text-destructive">
+              Error: {keyError}
+            </p>
+          )}
+          <div className="text-sm text-muted-foreground">
+            {!sourceProjectHasKey && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <p>Select a key to link your cloned project to your organization. &#9432;</p>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Organization keys are required for cloning private repositories. Add this project's Deploy Key to your Git service.
+                </TooltipContent>
+              </Tooltip>
+            )}
+            <Link href={`/organizations/${organizationSlug}/keys`} className="underline">
+              Don&apos;t have an organization key? Create a key here.
+            </Link>
+          </div>
+        </div>
+
         <div className="space-y-3">
           <p className="text-sm font-medium">What to clone</p>
           <div className="border rounded-lg p-4 space-y-3">
@@ -179,7 +297,6 @@ export const ConfigureStep: FC<ConfigureStepProps> = ({
           </div>
         </div>
 
-      <div className="space-y-3">
         <Alert>
           <Info className="h-4 w-4" />
           <AlertTitle>Note</AlertTitle>
@@ -188,25 +305,16 @@ export const ConfigureStep: FC<ConfigureStepProps> = ({
             creation.
           </AlertDescription>
         </Alert>
-        {/* temporary measure to highlight cloning limitation for private repos */}
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Limitation</AlertTitle>
-          <AlertDescription>
-            Private repositories are currently not supported for cloning and will result in a failure.
-          </AlertDescription>
-        </Alert>
       </div>
-    </div>
 
-    <DialogFooter>
-      <Button variant="outline" onClick={onClose}>
-        Cancel
-      </Button>
-      <Button disabled={!isFormValid || envLoading} onClick={onClone}>
-        Clone Project
-      </Button>
-    </DialogFooter>
-  </>
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button disabled={!isFormValid || envLoading} onClick={onClone}>
+          Clone Project
+        </Button>
+      </DialogFooter>
+    </>
   );
 };

--- a/src/components/createOrgKey/CreateOrgKey.tsx
+++ b/src/components/createOrgKey/CreateOrgKey.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react';
+
+import AddOrgKeySheet from '@/components/createOrgKey/_components/AddOrgKeySheet';
+
+interface Props {
+  organizationName: string;
+  variant?: 'default' | 'small';
+  refetch?: () => void;
+}
+export const CreateOrgKey: FC<Props> = ({ organizationName, variant = 'default', refetch }) => {
+  return (
+    <>
+      <div className="flex gap-2 items-center">
+        <span className="text mr-4">Create a new key</span>
+        <AddOrgKeySheet organizationName={organizationName} />
+      </div>
+    </>
+  );
+};

--- a/src/components/createOrgKey/_components/AddOrgKeySheet.tsx
+++ b/src/components/createOrgKey/_components/AddOrgKeySheet.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import addOrganizationKey from '@/lib/mutation/organizations/addOrganizationKey';
+import { useMutation } from '@apollo/client';
+import { Sheet } from '@/ui-library';
+import { toast } from 'sonner';
+
+const AddOrgKeySheet = ({
+  organizationName,
+}: {
+  organizationName: string;
+}) => {
+  const [addKeyMutation, { error, loading }] = useMutation(addOrganizationKey, {
+    refetchQueries: ['getOrganization'],
+    onCompleted: () => {
+      toast.success('Key created successfully!');
+    },
+  });
+
+  const handleAddKey = async (e: React.MouseEvent<HTMLButtonElement>, values: any) => {
+    try {
+      const { keyName, keyComment } = values;
+
+      await addKeyMutation({
+        variables: {
+          organization: organizationName,
+          name: keyName,
+          comment: keyComment,
+        },
+      });
+    } catch (err) {
+      console.error('Error creating key:', err);
+      return false;
+    }
+  };
+
+  const keyErrorContent = (
+    <>
+      {error && (
+        <div className="text-red-500 p-3 border border-red-300 rounded-md mt-2 bg-red-50">
+          <strong>Error creating key:</strong> {error.message}
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <div className="space-y-4">
+      <Sheet
+        sheetTrigger="Create Key"
+        sheetTitle="Create an organization key"
+        sheetDescription="Enter the key details below"
+        sheetFooterButton="Create Key"
+        loading={loading}
+        error={!!error}
+        buttonAction={handleAddKey}
+        additionalContent={keyErrorContent}
+        sheetFields={[
+          {
+            id: 'keyName',
+            label: 'Key name',
+            type: 'text',
+            placeholder: 'Enter name',
+            required: true,
+          },
+          {
+            id: 'keyComment',
+            label: 'Comment',
+            type: 'textarea',
+            placeholder: 'Add an optional comment about this key',
+            required: false,
+          }
+        ]}
+      />
+    </div>
+  );
+};
+
+export default AddOrgKeySheet;

--- a/src/components/dynamicNavigation/DynamicNavigation.tsx
+++ b/src/components/dynamicNavigation/DynamicNavigation.tsx
@@ -78,6 +78,7 @@ export const getOrgNav = (organizationSlug: ParamValue, showVariables?: boolean)
         { title: 'Projects', url: `/organizations/${organizationSlug}/projects` },
         ...(showVariables ? [{ title: 'Variables', url: `/organizations/${organizationSlug}/variables` }] : []),
         { title: 'Notifications', url: `/organizations/${organizationSlug}/notifications` },
+        { title: 'Keys', url: `/organizations/${organizationSlug}/keys` },
         { title: 'Administration', url: `/organizations/${organizationSlug}/manage` },
       ],
     },

--- a/src/components/pages/organizations/keys/KeysDataTableColumns.tsx
+++ b/src/components/pages/organizations/keys/KeysDataTableColumns.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { handleSort, renderSortIcons } from '@/components/utils';
+import { Button, CopyToClipboard, DataTableColumnDef, Tooltip, TooltipContent, TooltipTrigger } from '@/ui-library';
+import { OrgProject } from '@/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/(organization-overview)/page';
+import { OrganizationKey } from '@/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/page';
+import { AddOrganizationKeyToProject } from '@/components/addOrgKeyToProject/AddOrgKeyToProject';
+import { DeleteKey } from './_components/DeleteKey';
+import { RemoveKeyFromProject } from './_components/RemoveKeyFromProject';
+import { UpdateKey } from './_components/UpdateKey';
+
+export const KeysDataTableColumns = (
+  organizationSlug?: string,
+  projects?: OrgProject[],
+  keys?: OrganizationKey[],
+  refetch?: () => void
+): DataTableColumnDef<OrganizationKey>[] => {
+  const assignedProjects = new Set(
+    (keys ?? []).flatMap(key => (key.projects ?? []).map(proj => proj.name))
+  );
+
+  const availableProjects = (projects ?? []).filter(proj => !assignedProjects.has(proj.name));
+
+  return [
+    {
+      accessorKey: 'name',
+      sortingFn: (rowA, rowB, columnId) => {
+        const a = rowA.getValue(columnId) as string;
+        const b = rowB.getValue(columnId) as string;
+        return a.localeCompare(b);
+      },
+      width: '20%',
+      header: ({ column }) => {
+        const sortDirection = column.getIsSorted();
+
+        return (
+          <Button variant="ghost" className="px-1" onClick={() => handleSort(sortDirection, column)}>
+            Key Name
+            <div className="flex flex-col">{renderSortIcons(sortDirection)}</div>
+          </Button>
+        );
+      },
+      cell: ({ row }) => {
+        const { name } = row.original;
+
+        return (
+          <div className="max-w-[25vw] flex gap-4">
+            {name}
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: 'created',
+      sortingFn: (rowA, rowB, columnId) => {
+        const a = (rowA.getValue(columnId) as number) || 0;
+        const b = (rowB.getValue(columnId) as number) || 0;
+        return a - b;
+      },
+      width: '15%',
+      header: ({ column }) => {
+        const sortDirection = column.getIsSorted();
+
+        return (
+          <Button variant="ghost" className="px-1" onClick={() => handleSort(sortDirection, column)}>
+            Created
+            <div className="flex flex-col">{renderSortIcons(sortDirection)}</div>
+          </Button>
+        );
+      },
+      cell: ({ row }) => {
+        const created = row.original.created ?? 0;
+        return <div className="max-w-[25vw]">{created}</div>;
+      },
+    },
+    {
+      accessorKey: 'comment',
+      width: '25%',
+      header: 'Comment',
+      cell: ({ row }) => {
+        const comment = row.original.comment ?? '';
+        return <div className="max-w-[25vw]">{comment}</div>;
+      },
+    },
+    {
+      accessorKey: 'publicKey',
+      width: '20%',
+      header: 'Public Key',
+      cell: ({ row }) => {
+        const publicKey = row.original.publicKey ?? '';
+        return (
+          <div className="max-w-[20vw]">
+            {publicKey ? <CopyToClipboard withToolTip text={publicKey} type="hiddenWithIcon" /> : ''}
+          </div>
+        );
+      },
+    },
+    {
+      id: 'actions',
+      header: 'Actions',
+      width: '20%',
+      cell: ({ row }) => {
+        const orgKey = row.original;
+        const noAvailableProjects = availableProjects.length === 0;
+        const notAssignedToProject = !orgKey.projects || orgKey.projects.length === 0;
+
+        return (
+          <div className="flex items-center gap-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <AddOrganizationKeyToProject
+                    keyId={orgKey.id}
+                    keyName={orgKey.name}
+                    projects={availableProjects}
+                    disabled={noAvailableProjects}
+                    refetch={refetch}
+                  />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {noAvailableProjects ? 'All projects already have an org key' : 'Add Key to a Project'}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <RemoveKeyFromProject orgKey={orgKey} refetch={refetch!} />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {notAssignedToProject ? 'Key is not assigned to any project' : 'Remove Key from Project'}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <UpdateKey orgKey={orgKey} refetch={refetch!} />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Update Key</TooltipContent>
+            </Tooltip>
+            <DeleteKey orgKey={orgKey} refetch={refetch!} />
+          </div>
+        );
+      },
+    },
+  ];
+};
+
+export default KeysDataTableColumns;

--- a/src/components/pages/organizations/keys/KeysPage.tsx
+++ b/src/components/pages/organizations/keys/KeysPage.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import React from 'react';
+
+import SectionWrapper from '@/components/SectionWrapper/SectionWrapper';
+import OrganizationNotFound from '@/components/errors/OrganizationNotFound';
+import { QueryRef, useQueryRefHandlers, useReadQuery } from '@apollo/client';
+import { DataTable, SelectWithOptions } from '@/ui-library';
+import { useQueryStates } from 'nuqs';
+
+import KeysDataTableColumns from './KeysDataTableColumns';
+import { CreateOrgKey } from '@/components/createOrgKey/CreateOrgKey';
+import { OrganizationKeysData } from '@/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/page';
+
+export default function KeysPage({
+  queryRef,
+  organizationSlug,
+}: {
+  queryRef: QueryRef<OrganizationKeysData>;
+  organizationSlug: string;
+}) {
+  const [{ results }, setQuery] = useQueryStates({
+    results: {
+      defaultValue: 10,
+      parse: (value: string | undefined) => (value !== undefined ? Number(value) : 10),
+    },
+  });
+
+  const setResults = (val: string) => {
+    setQuery({ results: Number(val) });
+  };
+
+  const { refetch } = useQueryRefHandlers(queryRef);
+
+  const { data: { organization } } = useReadQuery(queryRef);
+
+  if (!organization) {
+    return <OrganizationNotFound orgName={organizationSlug} />;
+  }
+
+  return (
+    <SectionWrapper>
+      <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">Organization Keys</h3>
+      <div className="gap-4 my-4">
+        <CreateOrgKey organizationName={organization.name} />
+      </div>
+      <DataTable
+        columns={KeysDataTableColumns(organizationSlug, organization.projects, organization.keys, refetch)}
+        data={organization.keys}
+        searchableColumns={['name']}
+        initialPageSize={results || 10}
+        renderFilters={table => (
+          <div className="flex items-center gap-4">
+            <SelectWithOptions
+              options={[
+                { label: '10 results per page', value: 10 },
+                { label: '20 results per page', value: 20 },
+                { label: '50 results per page', value: 50 },
+              ]}
+              width={100}
+              value={String(results || 10)}
+              placeholder="Results per page"
+              onValueChange={newVal => {
+                table.setPageSize(Number(newVal));
+                setResults(newVal);
+              }}
+            />
+          </div>
+        )}
+      />
+    </SectionWrapper>
+  );
+}

--- a/src/components/pages/organizations/keys/_components/DeleteKey.tsx
+++ b/src/components/pages/organizations/keys/_components/DeleteKey.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import DeleteNoConfirm from '@/components/deleteNoConfirm/DeleteNoConfirm';
+import deleteOrganizationKey from '@/lib/mutation/organizations/deleteOrganizationKey';
+import { OrganizationKey } from '@/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/page';
+import { useMutation } from '@apollo/client';
+import { toast } from 'sonner';
+
+type DeleteKeyProps = {
+  orgKey: OrganizationKey;
+  refetch: () => void;
+};
+
+export const DeleteKey: React.FC<DeleteKeyProps> = ({ orgKey, refetch }) => {
+  const { id, name } = orgKey;
+  const [deleteKeyMutation, { loading }] = useMutation(deleteOrganizationKey, {
+    variables: {
+      id,
+    },
+    refetchQueries: ['getOrganization'],
+    onCompleted: () => {
+      toast.success('Key deleted successfully!');
+    },
+  });
+
+  return (
+    <DeleteNoConfirm
+      deleteType="delete"
+      deleteItemType="key"
+      title="Delete key?"
+      loading={loading}
+      deleteMessage={
+        <>
+          <p>
+            This action will delete key <span className="highlight">{name}</span> from this organization.
+          </p>
+        </>
+      }
+      action={() => deleteKeyMutation()}
+      refetch={refetch}
+    />
+  );
+};

--- a/src/components/pages/organizations/keys/_components/RemoveKeyFromProject.tsx
+++ b/src/components/pages/organizations/keys/_components/RemoveKeyFromProject.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { OrganizationKey } from '@/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/page';
+import removeOrganizationKeyFromProject from '@/lib/mutation/organizations/removeOrganizationKeyFromProject';
+import { useMutation } from '@apollo/client';
+import { Unlink } from 'lucide-react';
+import { Sheet } from '@/ui-library';
+import { toast } from 'sonner';
+
+type RemoveKeyFromProjectProps = {
+  orgKey: OrganizationKey;
+  refetch: () => void;
+};
+
+export const RemoveKeyFromProject: React.FC<RemoveKeyFromProjectProps> = ({ orgKey, refetch }) => {
+  const { id, name, projects } = orgKey;
+
+  const [removeKeyFromProjectMutation, { error, loading }] = useMutation(removeOrganizationKeyFromProject, {
+    refetchQueries: ['getOrganization'],
+    onCompleted: () => {
+      toast.success('Key removed from project successfully!');
+      refetch();
+    },
+  });
+
+  const handleRemove = async (_e: React.MouseEvent<HTMLButtonElement>, values: any) => {
+    try {
+      const { project } = values;
+      await removeKeyFromProjectMutation({
+        variables: {
+          id,
+          project,
+        },
+      });
+    } catch (err) {
+      console.error('Error removing key from project:', err);
+      return false;
+    }
+  };
+
+  const projectOptions = (projects ?? []).map(p => ({ label: p.name, value: p.name }));
+  const hasProjects = projectOptions.length > 0;
+
+  return (
+    <Sheet
+      disabled={!hasProjects}
+      sheetTrigger={<Unlink className="h-5 w-5" />}
+      sheetTitle={`Remove key "${name}" from a project`}
+      sheetDescription="Select a project to remove this key from."
+      sheetFooterButton="Confirm"
+      loading={loading}
+      error={!!error}
+      buttonAction={handleRemove}
+      additionalContent={
+        error ? (
+          <div className="text-red-500 p-3 border border-red-300 rounded-md mt-2 bg-red-50">
+            <strong>Error:</strong> {error.message}
+          </div>
+        ) : null
+      }
+      sheetFields={[
+        {
+          id: 'project',
+          label: 'Project',
+          required: true,
+          placeholder: projectOptions.length > 0 ? 'Select a project' : 'No projects assigned',
+          type: 'select',
+          options: projectOptions,
+        },
+      ]}
+    />
+  );
+};

--- a/src/components/pages/organizations/keys/_components/UpdateKey.tsx
+++ b/src/components/pages/organizations/keys/_components/UpdateKey.tsx
@@ -23,7 +23,6 @@ export const UpdateKey: React.FC<UpdateKeyProps> = ({ orgKey, refetch }) => {
   
   const handleUpdateKey = async (e: React.MouseEvent<HTMLButtonElement>, values: any) => {
     const { comment } = values;
-    console.log('Updating key with values:', { id, comment });
     updateKeyMutation({
       variables: {
         id,
@@ -59,7 +58,7 @@ export const UpdateKey: React.FC<UpdateKeyProps> = ({ orgKey, refetch }) => {
             label: 'Comment',
             type: 'text',
             placeholder: 'Update comment',
-            required: true,
+            inputDefault: orgKey.comment || '',
           },
         ]}
       />

--- a/src/components/pages/organizations/keys/_components/UpdateKey.tsx
+++ b/src/components/pages/organizations/keys/_components/UpdateKey.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import updateOrganizationKey from '@/lib/mutation/organizations/updateOrganizationKey';
+import { OrganizationKey } from '@/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/page';
+import { useMutation } from '@apollo/client';
+import { toast } from 'sonner';
+import Sheet from '@/ui-library/components/Sheet/Sheet';
+import { Pencil } from 'lucide-react';
+
+type UpdateKeyProps = {
+  orgKey: OrganizationKey;
+  refetch: () => void;
+};
+
+export const UpdateKey: React.FC<UpdateKeyProps> = ({ orgKey, refetch }) => {
+  const { id } = orgKey;
+  const [updateKeyMutation, { error, loading }] = useMutation(updateOrganizationKey, {
+    refetchQueries: ['getOrganization'],
+    onCompleted: () => {
+      toast.success('Key updated successfully!');
+    },
+  });
+  
+  const handleUpdateKey = async (e: React.MouseEvent<HTMLButtonElement>, values: any) => {
+    const { comment } = values;
+    console.log('Updating key with values:', { id, comment });
+    updateKeyMutation({
+      variables: {
+        id,
+        comment,
+      },
+    });
+  };
+
+  const keyErrorContent = (
+    <>
+      {error && (
+        <div className="text-red-500 p-3 border border-red-300 rounded-md mt-2 bg-red-50">
+          <strong>Error updating key:</strong> {error.message}
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <div className="space-y-4">
+      <Sheet
+        sheetTrigger={<Pencil className="h-5 w-5" aria-label="edit-route" />}
+        sheetTitle="Update an organization key"
+        sheetDescription="Enter the key details below"
+        sheetFooterButton="Update Key"
+        loading={loading}
+        error={!!error}
+        buttonAction={handleUpdateKey}
+        additionalContent={keyErrorContent}
+        sheetFields={[
+          {
+            id: 'comment',
+            label: 'Comment',
+            type: 'text',
+            placeholder: 'Update comment',
+            required: true,
+          },
+        ]}
+      />
+    </div>
+  );
+};

--- a/src/components/pages/organizations/project/OrgProjectPage.tsx
+++ b/src/components/pages/organizations/project/OrgProjectPage.tsx
@@ -145,7 +145,7 @@ export default function OrgProjectPage({
     <SectionWrapper>
       {projectCloneEnabled && (
         <div className="mb-6 flex items-center gap-4 float-right">
-            <CloneProject projectName={project.name} organizationSlug={organization.name} refetch={refetch} toggleText />
+            <CloneProject projectName={project.name} organizationSlug={organization.name} refetch={refetch} toggleText keys={[]} />
         </div>
       )}
       <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight mb-4">Groups for {project.name}</h3>

--- a/src/components/pages/organizations/projects/ProjectsPage.tsx
+++ b/src/components/pages/organizations/projects/ProjectsPage.tsx
@@ -149,6 +149,8 @@ export default function OrgProjectsPage({
     return { ...project, clone: { ...(project.clone ?? {}), status: overrideStatus } };
   });
 
+  const orgKeys = organization?.keys || [];
+
   return (
     <>
       <SectionWrapper>
@@ -163,6 +165,7 @@ export default function OrgProjectsPage({
             ),
             organization.name,
             projectCloneEnabled,
+            orgKeys,
             refetchData
           )}
           data={projectsWithOverrides.sort((a, b) => {

--- a/src/components/pages/organizations/projects/_components/ProjectsDataTableColumns.tsx
+++ b/src/components/pages/organizations/projects/_components/ProjectsDataTableColumns.tsx
@@ -7,6 +7,7 @@ import { CloneProject } from '@/components/cloneProject/CloneProject';
 import { handleSort, renderSortIcons } from '@/components/utils';
 import { Badge, Button, DataTableColumnDef, Tooltip, TooltipContent, TooltipTrigger, cn } from '@/ui-library';
 import { FolderCog } from 'lucide-react';
+import { OrganizationKey } from '@/app/(routegroups)/(orgroutes)/organizations/[organizationSlug]/keys/page';
 
 const setCloneBadge = (status?: string) => {
   if (!status) return null;
@@ -19,24 +20,11 @@ const setCloneBadge = (status?: string) => {
   }
 }
 
-// temporary measure to block cloning for private repos
-const validateCloneRepo = (gitUrl: string) => {
-  if (gitUrl.startsWith('git@') || gitUrl.startsWith('ssh://')) {
-    return false;
-  }
-
-  try {
-    const url = new URL(gitUrl);
-    return url.protocol === 'http:' || url.protocol === 'https:';
-  } catch (err) {
-    return false;
-  }
-}
-
 export const ProjectsDataTableColumns = (
   deleteProjectModal: (project: OrgProject) => React.ReactNode,
   orgName: string,
   projectCloneEnabled: boolean,
+  orgKeys: OrganizationKey[],
   refetch?: () => void
 ): DataTableColumnDef<OrgProject>[] => [
   {
@@ -88,10 +76,9 @@ export const ProjectsDataTableColumns = (
           {projectCloneEnabled && (
             <Tooltip>
               <TooltipTrigger>
-                {/* disabled for private repos via validateCloneRepo */}
-                <CloneProject projectName={row.original.name} organizationSlug={orgName} refetch={refetch} disabled={!validateCloneRepo(row.original.gitUrl || '')} />
+                <CloneProject projectName={row.original.name} organizationSlug={orgName} refetch={refetch} keys={orgKeys} />
               </TooltipTrigger>
-              <TooltipContent>{!validateCloneRepo(row.original.gitUrl || '') ? 'Private repository: not eligible for cloning' : 'Clone this Project'}</TooltipContent>
+              <TooltipContent>Clone this Project</TooltipContent>
             </Tooltip>
           )}
           <Button>

--- a/src/lib/mutation/organizations/addOrganizationKey.ts
+++ b/src/lib/mutation/organizations/addOrganizationKey.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation addOrganizationKey($organization: String!, $name: String!, $comment: String) {
+    addOrganizationKey(input: { organization: $organization, name: $name, comment: $comment }) {
+      id
+      name
+      publicKey
+      comment
+      created
+    }
+  }
+`;

--- a/src/lib/mutation/organizations/addOrganizationKeyToProject.ts
+++ b/src/lib/mutation/organizations/addOrganizationKeyToProject.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation addOrganizationKeyToProject($id: Int!, $project: String!) {
+    addOrganizationKeyToProject(id: $id, project: $project) {
+      id
+    }
+  }
+`;

--- a/src/lib/mutation/organizations/deleteOrganizationKey.ts
+++ b/src/lib/mutation/organizations/deleteOrganizationKey.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation deleteOrganizationKey($id: Int!) {
+    deleteOrganizationKey(id: $id)
+  }
+`;

--- a/src/lib/mutation/organizations/removeOrganizationKeyFromProject.ts
+++ b/src/lib/mutation/organizations/removeOrganizationKeyFromProject.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation removeOrganizationKeyFromProject($id: Int!, $project: String!) {
+    removeOrganizationKeyFromProject(id: $id, project: $project) {
+      id
+    }
+  }
+`;

--- a/src/lib/mutation/organizations/updateOrganizationKey.ts
+++ b/src/lib/mutation/organizations/updateOrganizationKey.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  mutation updateOrganizationKey($id: Int!, $comment: String!) {
+    updateOrganizationKey(id: $id, comment: $comment) {
+      id
+    }
+  }
+`;

--- a/src/lib/query/organizations/organizationByName.keys.ts
+++ b/src/lib/query/organizations/organizationByName.keys.ts
@@ -1,0 +1,28 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  query getOrganization($name: String!) {
+    organization: organizationByName(name: $name) {
+      id
+      name
+      projects {
+        id
+        name
+        clone {
+          status
+        }
+      }
+      keys {
+        id
+        name
+        publicKey
+        comment
+        created
+        projects {
+          id
+          name
+        }
+      }
+    }
+  }
+`;

--- a/src/lib/query/organizations/organizationByName.projects.ts
+++ b/src/lib/query/organizations/organizationByName.projects.ts
@@ -10,7 +10,6 @@ export default gql`
         id
         name
         groupCount
-        gitUrl
         clone {
           status
         }
@@ -20,6 +19,13 @@ export default gql`
         name
       }
       featureProjectClone
+      keys {
+        id
+        name
+        projects {
+          name
+        }
+      }
     }
   }
 `;


### PR DESCRIPTION
Based off https://github.com/uselagoon/lagoon-beta-ui/pull/145 - updates the `project-clone` branch to include the new UI workflow for organization deploy keys.

Adds a `keys` tab to an Organization where the user can add, update, delete or assign/unassign an organization key to a Project. Also updates the project clone modal to allow for an organization key to be assigned to a Project.

Requires https://github.com/uselagoon/lagoon/pull/4079