### PR TITLE
Chore: Update licenses dependency-review-config 

### DIFF
--- a/.github/dependency-review-config.yaml
+++ b/.github/dependency-review-config.yaml
@@ -22,3 +22,21 @@ allow-licenses:
 - 'Zlib'
 # Google's patent licence for Go
 - 'LicenseRef-scancode-google-patent-license-golang'
+- 'MPL-2.0'
+
+allow-dependencies-licenses:
+- 'pkg:npm/caniuse-lite'
+- 'pkg:npm/%40img%2Fsharp-libvips-darwin-arm64'
+- 'pkg:npm/%40img%2Fsharp-libvips-darwin-x64'
+- 'pkg:npm/%40img%2Fsharp-libvips-linux-arm'
+- 'pkg:npm/%40img%2Fsharp-libvips-linux-arm64'
+- 'pkg:npm/%40img%2Fsharp-libvips-linux-ppc64'
+- 'pkg:npm/%40img%2Fsharp-libvips-linux-riscv64'
+- 'pkg:npm/%40img%2Fsharp-libvips-linux-s390x'
+- 'pkg:npm/%40img%2Fsharp-libvips-linux-x64'
+- 'pkg:npm/%40img%2Fsharp-libvips-linuxmusl-arm64'
+- 'pkg:npm/%40img%2Fsharp-libvips-linuxmusl-x64'
+- 'pkg:npm/%40img%2Fsharp-win32-arm64'
+- 'pkg:npm/%40img%2Fsharp-win32-ia32'
+- 'pkg:npm/%40img%2Fsharp-win32-x64'
+- 'pkg:npm/type-fest'

--- a/.github/dependency-review-config.yaml
+++ b/.github/dependency-review-config.yaml
@@ -22,10 +22,13 @@ allow-licenses:
 - 'Zlib'
 # Google's patent licence for Go
 - 'LicenseRef-scancode-google-patent-license-golang'
+# lightningcss pulled in by @tailwindcss
 - 'MPL-2.0'
 
 allow-dependencies-licenses:
+# CC-BY-4.0: Build dependency pulled in by Next & browserslist
 - 'pkg:npm/caniuse-lite'
+# LGPL/MPL: Image optimization for Next
 - 'pkg:npm/%40img%2Fsharp-libvips-darwin-arm64'
 - 'pkg:npm/%40img%2Fsharp-libvips-darwin-x64'
 - 'pkg:npm/%40img%2Fsharp-libvips-linux-arm'
@@ -39,4 +42,5 @@ allow-dependencies-licenses:
 - 'pkg:npm/%40img%2Fsharp-win32-arm64'
 - 'pkg:npm/%40img%2Fsharp-win32-ia32'
 - 'pkg:npm/%40img%2Fsharp-win32-x64'
+# CC0-1.0: Pulled in by storybook
 - 'pkg:npm/type-fest'


### PR DESCRIPTION
Adds `MPL-2.0` as an allowed licence + `img/sharp`, `caniuse-lite` & `type-fest` under allow-dependencies-licenses